### PR TITLE
Replace ScanCode with FOSSLight Source

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,6 @@ XlsxWriter
 parmap
 ruamel.yaml
 py-tlsh
-scancode-toolkit==32.0.6
 tqdm
 fosslight_binary>=4.1.8
+fosslight_source>=1.7.3


### PR DESCRIPTION
## Description
<!--
Please describe what this PR do.
 -->
Replace ScanCode with FOSSLight Source.
Reason: 
- Resolve version conflict issue when installing other FOSSLight Scanners together.
- Scancode method is scheduled to be changed to FOSSLight Source.

## Type of change
<!--
Please insert 'x' one of the type of change.
 -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [x] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

