### PR TITLE
Print package information when using the y option

### DIFF
--- a/src/fosslight_yocto/_package_item.py
+++ b/src/fosslight_yocto/_package_item.py
@@ -90,6 +90,14 @@ class PackageItem(OssItem):
         self._oss_name = value
 
     @property
+    def name(self):
+        return self._name
+
+    @name.setter
+    def name(self, value):
+        self._name = value
+
+    @property
     def version(self):
         return self._version
 
@@ -178,7 +186,7 @@ class PackageItem(OssItem):
         exclude = EXCLUDE_TRUE_VALUE if self.exclude else ""
         if len(self.declared_licenses) > 0:
             license_to_print = self.declared_licenses
-        if bin_android_format:  # BIN(Android) Sheet
+        if bin_android_format:  # BIN(Yocto) Sheet
             row = [self.parent_package_name, self.oss_name, "", self.name, self.version,
                    ','.join(license_to_print),
                    self.download_location, self.homepage, self.copyright, exclude, self.comment]


### PR DESCRIPTION
## Description
<!--
Please describe what this PR do.
 -->
Print package information when using the y option.
oss-pkg-info.yaml : 
```
- name : bazel
  source : https://github.com/bazelbuild/bazel
  license : Apache-2.0
  file : build/
  exclude : True
  comment : Script for build
  yocto_recipe: kmod
  yocto_package:
  - netbase
  - kernel-base
 ```
* AS-IS : 
     ![image](https://github.com/fosslight/fosslight_yocto_scanner/assets/4284712/a86dbe26-e058-45ff-aefc-881d7ad9c9bd)
* TO-BE:
     ![image](https://github.com/fosslight/fosslight_yocto_scanner/assets/4284712/344bf3d7-47c9-4c36-b5b9-b8e01624c1cf)

## Type of change
<!--
Please insert 'x' one of the type of change.
 -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Refactoring, Maintenance
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

