### PR TITLE
Fix AttributeError Related to os.EX_DATAERR and os.EX_NOINPUT in Windows Environment

### DIFF
--- a/src/fosslight_yocto/create_oss_report_for_yocto.py
+++ b/src/fosslight_yocto/create_oss_report_for_yocto.py
@@ -71,6 +71,8 @@ additional_columns = []
 printall = False  # Print all values in bom.json
 OSC_DB_USER = 'user_oss_license'
 OSC_DB_PASSWORD = 'oss_lic123'
+EX_DATAERR = 65
+EX_NOINPUT = 66
 
 
 def read_installed_pkg_file(installed_pkg_names_file):
@@ -123,7 +125,7 @@ def check_json_validate(bom_file):
         if file_content is not None:
             file_content = file_content.strip()
     except Exception:
-        exit_with_error_msg("Can't read a bom.json", os.EX_NOINPUT)
+        exit_with_error_msg("Can't read a bom.json", EX_NOINPUT)
 
     # Dafault bom.json file isn't loadable.
     json_obj = get_json_object(file_content)
@@ -449,10 +451,10 @@ def check_required_files(bom, installed_pkgs, buildhistory_path, installed_pkgs_
         error_msg = "-ip installed-packages.txt\n"
 
     if error_msg != "":
-        exit_with_error_msg("Check Arguments\n" + error_msg, os.EX_NOINPUT)
+        exit_with_error_msg("Check Arguments\n" + error_msg, EX_NOINPUT)
 
 
-def exit_with_error_msg(error_mgs, exit_code=os.EX_DATAERR):
+def exit_with_error_msg(error_mgs, exit_code=EX_DATAERR):
     logger.error(error_mgs)
     sys.exit(exit_code)
 


### PR DESCRIPTION
## Description
This pull request addresses the AttributeError issues that occur in Windows environments where the os module does not have the attributes EX_DATAERR and EX_NOINPUT. These attributes are Unix-specific and are not available on all platforms, particularly Windows. Specifically, these issues were triggered in the exit_with_error_msg() and check_json_validate() functions.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

