### PR TITLE
Fix typo in variable name from error_mgs to error_msg

### DIFF
--- a/src/fosslight_yocto/create_oss_report_for_yocto.py
+++ b/src/fosslight_yocto/create_oss_report_for_yocto.py
@@ -454,8 +454,8 @@ def check_required_files(bom, installed_pkgs, buildhistory_path, installed_pkgs_
         exit_with_error_msg("Check Arguments\n" + error_msg, EX_NOINPUT)
 
 
-def exit_with_error_msg(error_mgs, exit_code=EX_DATAERR):
-    logger.error(error_mgs)
+def exit_with_error_msg(error_msg, exit_code=EX_DATAERR):
+    logger.error(error_msg)
     sys.exit(exit_code)
 
 


### PR DESCRIPTION
## Description
This PR corrects a typo in the function exit_with_error_msg. The variable name error_mgs was misspelled, and it has been updated to error_msg for better readability and consistency

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [x] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

